### PR TITLE
feat(validate): add providerSummary to validation output (provider, p…

### DIFF
--- a/src/backend/yaml/types.ts
+++ b/src/backend/yaml/types.ts
@@ -12,9 +12,27 @@ export interface LintMessage {
   suggestion?: string
 }
 
+export interface SourceCounts {
+  errors: number
+  warnings: number
+  infos: number
+}
+
+export interface ProviderSummary {
+  provider: 'aws' | 'azure' | 'generic'
+  sources: {
+    azureSchemaPath?: string
+    cfnSpecPath?: string
+    spectralRulesetPath?: string
+    cfnLintDockerImage?: string
+  }
+  counts: Partial<Record<LintSource, SourceCounts>>
+}
+
 export interface LintResult {
   ok: boolean
   messages: LintMessage[]
+  providerSummary?: ProviderSummary
 }
 
 export interface ValidateOptions {

--- a/src/backend/yaml/validate.ts
+++ b/src/backend/yaml/validate.ts
@@ -1,6 +1,6 @@
 import { parseWithTimeout } from './parseSafe'
 import { isLikelyCloudFormation, isLikelyAzurePipelines, detectProvider } from './detect'
-import type { LintMessage, LintResult, ValidateOptions, ToolRunner, ProviderSummary, LintSource } from './types'
+import type { LintMessage, LintResult, ValidateOptions, ToolRunner, ProviderSummary } from './types'
 import { defaultToolRunner } from './toolRunner'
 import { preflightContentGuards, validateFileMeta } from './security'
 import fs from 'node:fs'
@@ -165,7 +165,7 @@ const res = await runner.run('docker', ['run', '--rm', '--network=none', '-v', `
       spectralRulesetPath,
       cfnLintDockerImage: runCfn ? cfnDockerImage : undefined,
     },
-    counts: counts as any,
+    counts: counts as unknown as ProviderSummary['counts'],
   }
 
   const ok = messages.every((m) => m.severity !== 'error')

--- a/src/backend/yaml/validate.ts
+++ b/src/backend/yaml/validate.ts
@@ -1,8 +1,9 @@
 import { parseWithTimeout } from './parseSafe'
-import { isLikelyCloudFormation, isLikelyAzurePipelines } from './detect'
-import type { LintMessage, LintResult, ValidateOptions, ToolRunner } from './types'
+import { isLikelyCloudFormation, isLikelyAzurePipelines, detectProvider } from './detect'
+import type { LintMessage, LintResult, ValidateOptions, ToolRunner, ProviderSummary, LintSource } from './types'
 import { defaultToolRunner } from './toolRunner'
 import { preflightContentGuards, validateFileMeta } from './security'
+import fs from 'node:fs'
 
 function pushParserError(e: unknown, messages: LintMessage[]) {
   const msg = e instanceof Error ? e.message : String(e)
@@ -63,15 +64,13 @@ export async function validateYaml(content: string, options: ValidateOptions = {
 
   // cfn-lint (CloudFormation), only if CFN detected or forced
   const runCfn = options.assumeCloudFormation || isLikelyCloudFormation(content)
+  const cfnDockerImage = 'giammbo/cfn-lint:latest'
   if (runCfn) {
     try {
-      // Use dockerized cfn-lint if available, otherwise npx cfn-lint if installed globally
-      // Prefer stdin via temp file workaround: cfn-lint expects a file. We'll pass via - (stdin) is not supported; so skip stdin and fallback to docker echo piping.
-      // Create a temp file approach: not writing files in this utility; instead, rely on caller to provide filename if needed.
       if (!options.filename) {
         messages.push({ source: 'cfn-lint', message: 'CFN detection true but no filename provided; cfn-lint requires a file path. Skipped.', severity: 'info' })
       } else {
-const res = await runner.run('docker', ['run', '--rm', '--network=none', '-v', `${process.cwd()}:${process.cwd()}:ro`, '-w', process.cwd(), 'giammbo/cfn-lint:latest', 'cfn-lint', '-f', 'json', options.filename])
+const res = await runner.run('docker', ['run', '--rm', '--network=none', '-v', `${process.cwd()}:${process.cwd()}:ro`, '-w', process.cwd(), cfnDockerImage, 'cfn-lint', '-f', 'json', options.filename])
         if (res.code !== 0 && res.stdout) {
           try {
             type CFNFinding = {
@@ -143,6 +142,32 @@ const res = await runner.run('docker', ['run', '--rm', '--network=none', '-v', `
     }
   }
 
+  // Build provider summary
+  const provider = detectProvider(content)
+  const counts: Record<string, { errors: number; warnings: number; infos: number }> = {}
+  const bump = (src: string, sev: 'error'|'warning'|'info') => {
+    if (!counts[src]) counts[src] = { errors: 0, warnings: 0, infos: 0 }
+    if (sev === 'error') counts[src].errors++
+    else if (sev === 'warning') counts[src].warnings++
+    else counts[src].infos++
+  }
+  for (const m of messages) bump(m.source, m.severity)
+
+  const azureSchemaPath = process.env.AZURE_PIPELINES_SCHEMA_PATH && fs.existsSync(process.env.AZURE_PIPELINES_SCHEMA_PATH) ? process.env.AZURE_PIPELINES_SCHEMA_PATH : undefined
+  const cfnSpecPath = process.env.CFN_SPEC_PATH && fs.existsSync(process.env.CFN_SPEC_PATH) ? process.env.CFN_SPEC_PATH : undefined
+  const spectralRulesetPath = options.spectralRulesetPath || process.env.SPECTRAL_RULESET || undefined
+
+  const providerSummary: ProviderSummary = {
+    provider,
+    sources: {
+      azureSchemaPath,
+      cfnSpecPath,
+      spectralRulesetPath,
+      cfnLintDockerImage: runCfn ? cfnDockerImage : undefined,
+    },
+    counts: counts as any,
+  }
+
   const ok = messages.every((m) => m.severity !== 'error')
-  return { ok, messages }
+  return { ok, messages, providerSummary }
 }

--- a/tests/backend/yaml/validation.azure.test.ts
+++ b/tests/backend/yaml/validation.azure.test.ts
@@ -12,5 +12,7 @@ describe('Azure validation integration', () => {
     const res = await validateYaml(azureBad, { assumeAzurePipelines: true, toolRunner: { run: async () => ({ code: 0, stdout: '', stderr: '' }) } })
     // Should not be ok due to type/unknown issues promoted as warnings; ok=true if no errors
     expect(res.messages.some(m => m.source === 'azure-schema')).toBe(true)
+    expect(res.providerSummary).toBeDefined()
+    expect(['azure','aws','generic']).toContain(res.providerSummary?.provider)
   })
 })

--- a/tests/backend/yaml/validation.test.ts
+++ b/tests/backend/yaml/validation.test.ts
@@ -79,6 +79,7 @@ describe('YAML validation', () => {
     const res = await validateYaml(yaml, { toolRunner: noopRunner })
     expect(res.ok).toBe(true)
     expect(res.messages.filter(m => m.severity === 'error')).toHaveLength(0)
+    expect(res.providerSummary).toBeDefined()
   })
 
   it('rejects invalid YAML (parser error)', async () => {


### PR DESCRIPTION
Summary
◦  Adds providerSummary to validateYaml results for easier consumption in UIs and tooling.
•  Details
◦  providerSummary.provider: 'aws' | 'azure' | 'generic' based on detection.
◦  providerSummary.sources:
▪  azureSchemaPath: resolved if AZURE_PIPELINES_SCHEMA_PATH exists.
▪  cfnSpecPath: resolved if CFN_SPEC_PATH exists.
▪  spectralRulesetPath: from CLI option or SPECTRAL_RULESET env.
▪  cfnLintDockerImage: 'giammbo/cfn-lint:latest' when CFN is validated.
◦  providerSummary.counts: per-source errors/warnings/infos (parser, yamllint, cfn-lint, spectral, azure-schema).
•  Why
◦  Improves UX for front-end and automation by providing a single, structured summary of provider and analyzer results.
•  Tests
◦  validation.test.ts: asserts providerSummary on generic/valid YAML.
◦  validation.azure.test.ts: asserts providerSummary present and provider is in ['azure','aws','generic'].
•  Notes
◦  No breaking changes; the providerSummary field is additive.