### PR TITLE
feat(icons): integrate lucide-react and replace inline SVGs

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetTrigger, SheetClose } from '@/components/ui/sheet'
-import { Menu } from 'lucide-react'
+import { Menu, CloudCog } from 'lucide-react'
 import { ModeToggle } from '@/components/mode-toggle'
 
 export function Navbar() {
@@ -9,7 +9,7 @@ export function Navbar() {
     <header className="sticky top-0 z-30 w-full border-b bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container mx-auto flex h-14 items-center justify-between px-4">
         <div className="flex items-center gap-3">
-          <div className="h-6 w-6 rounded bg-primary" aria-hidden />
+          <CloudCog aria-hidden className="h-6 w-6 text-primary" />
           <Link to="/" className="font-semibold">Cloudlint</Link>
         </div>
         <nav className="hidden items-center gap-6 md:flex">

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -3,22 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { LottiePlayer } from '@/components/LottiePlayer'
-
-function IconCloud() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 64 64" className="h-10 w-10 text-primary"><defs><linearGradient id="g1" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stopColor="currentColor" /><stop offset="1" stopColor="currentColor" /></linearGradient></defs><circle cx="32" cy="32" r="28" fill="currentColor" className="opacity-10"/><path d="M20 38c0-7 6-13 14-13s14 6 14 13c-4 0-8 3-14 3s-10-3-14-3z" fill="currentColor"/></svg>
-  )
-}
-function IconShield() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24" className="h-6 w-6 text-emerald-600"><path fill="currentColor" d="M12 2 4 5v6c0 5 3.4 9.7 8 11 4.6-1.3 8-6 8-11V5l-8-3Zm0 18c-3-1-6-4.7-6-9V6.3l6-2.2 6 2.2V11c0 4.3-3 8-6 9Z"/></svg>
-  )
-}
-function IconDiff() {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 24 24" className="h-6 w-6 text-blue-600"><path fill="currentColor" d="M9 3H5a2 2 0 0 0-2 2v4h2V5h4V3Zm10 10h2v4a2 2 0 0 1-2 2h-4v-2h4v-4Zm0-8a2 2 0 0 1 2 2v4h-2V7h-4V5h4ZM3 13h2v4h4v2H5a2 2 0 0 1-2-2v-4Zm6-2h6v2H9v-2Z"/></svg>
-  )
-}
+import { Cloud, Shield, GitCompare } from 'lucide-react'
 
 export default function About() {
   return (
@@ -70,7 +55,7 @@ export default function About() {
         <div className="grid gap-6 md:grid-cols-3">
           <Card>
             <CardHeader className="flex flex-row items-center gap-3">
-              <IconCloud />
+              <Cloud aria-hidden className="h-6 w-6 text-primary" />
               <div>
                 <CardTitle>Universal validation</CardTitle>
                 <CardDescription>AWS CFN, Azure Pipelines, and generic YAML</CardDescription>
@@ -83,7 +68,7 @@ export default function About() {
 
           <Card>
             <CardHeader className="flex flex-row items-center gap-3">
-              <IconDiff />
+              <GitCompare aria-hidden className="h-6 w-6 text-blue-600" />
               <div>
                 <CardTitle>Smart auto‑fix + diffs</CardTitle>
                 <CardDescription>Preview before you accept</CardDescription>
@@ -96,7 +81,7 @@ export default function About() {
 
           <Card>
             <CardHeader className="flex flex-row items-center gap-3">
-              <IconShield />
+              <Shield aria-hidden className="h-6 w-6 text-emerald-600" />
               <div>
                 <CardTitle>Security‑first</CardTitle>
                 <CardDescription>Privacy‑respecting by default</CardDescription>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -7,18 +7,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { LottiePlayer } from '@/components/LottiePlayer'
-
-function CoffeeIcon() {
-  return (
-    <svg aria-hidden="true" className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M18 8h2a3 3 0 0 1 0 6h-2" />
-      <path d="M2 8h16v6a6 6 0 0 1-6 6H8a6 6 0 0 1-6-6V8Z" />
-      <line x1="6" y1="2" x2="6" y2="4" />
-      <line x1="10" y1="2" x2="10" y2="4" />
-      <line x1="14" y1="2" x2="14" y2="4" />
-    </svg>
-  )
-}
+import { Coffee } from 'lucide-react'
 
 export default function Contact() {
   const [name, setName] = useState('')
@@ -59,7 +48,7 @@ export default function Contact() {
             <div className="mt-6">
               <Button asChild variant="secondary">
                 <a href="https://www.buymeacoffee.com/" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2">
-                  <CoffeeIcon /> Buy me a coffee
+                  <Coffee className="h-5 w-5" aria-hidden /> Buy me a coffee
                 </a>
               </Button>
             </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Upload } from 'lucide-react'
 
 function mockValidate(yaml: string): Promise<{ ok: boolean; messages: { message: string; severity: 'error'|'warning'|'info' }[]; fixed?: string }> {
   return new Promise((resolve) => {
@@ -87,7 +88,7 @@ export default function Home() {
               <div className="flex flex-wrap items-center gap-3">
                 <Button onClick={validate} disabled={validating}>{validating ? 'Validating…' : 'Validate'}</Button>
                 <Button variant="secondary" type="button" onClick={()=>fileRef.current?.click()} aria-describedby="upload-hint">
-                  <svg aria-hidden="true" className="mr-2 h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                  <Upload className="mr-2 h-4 w-4" aria-hidden />
                   Upload YAML
                 </Button>
                 <span id="upload-hint" className="sr-only">Choose a .yaml or .yml file to load into the editor</span>


### PR DESCRIPTION
- Navbar: use CloudCog as brand glyph
- Contact: replace coffee SVG with Coffee icon
- About: replace feature icons with Cloud, GitCompare, Shield
- Home: replace upload SVG with Upload

chore: install lucide-react